### PR TITLE
Update README docs URL to ichi0g0y.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 lol, friendl, cute React iconset
 
-[docs](https://lolicon.nantoka.works)
+[docs](https://lolicon.ichi0g0y.io)
 
 ## Usage
 


### PR DESCRIPTION
Switch the README docs link from the old nantoka.works domain to lolicon.ichi0g0y.io. This aligns the public docs URL with the renamed domain and current deployment target.