### PR TITLE
Fix LICENSE and add credits

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-Copyright 2018 Space Program Inc.
+Copyright 2026 Shinichi Yamashita (ichi0g0y)
+Copyright 2018 Space Program Inc. (Original: https://github.com/lachlanjc/spectrum-icons)
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Built with/supports TypeScript.
 | Prop   | Type             | Default | Details             |
 | ------ | ---------------- | ------- | ------------------- |
 | `size` | Number or string | `32`    | Sets width & height |
+
+## Credits
+
+Icon designs are based on [spectrum-icons](https://github.com/lachlanjc/spectrum-icons) by [@lachlanjc](https://github.com/lachlanjc), originally from [Spectrum](https://spectrum.chat)'s iconset.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "repository": "github:ichi0g0y/lolicon",
   "bugs": "https://github.com/ichi0g0y/lolicon/issues",
   "homepage": "https://github.com/ichi0g0y/lolicon#readme",
-  "author": "Shinichi Yamashita",
+  "author": "ichi0g0y",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Update copyright holder in LICENSE from original spectrum-icons project to ichi0g0y, add proper attribution in README's new Credits section, and update package.json author field for consistency.

- LICENSE: Update copyright holder and reference original spectrum-icons project
- README: Add Credits section with link to spectrum-icons
- package.json: Update author to ichi0g0y