### PR TITLE
🔧 root: publishタスクのバージョン取得をvarsセクションへ移動

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,8 +57,11 @@ tasks:
   # === パブリッシュ ===
   publish:
     desc: npmにパブリッシュ
+    vars:
+      VERSION:
+        sh: node -p "require('./package.json').version"
     cmds:
-      - echo "Publishing lolicon v$(node -p \"require('./package.json').version\")"
+      - echo "Publishing lolicon v{{.VERSION}}"
       - bun run build
       - npm publish
 


### PR DESCRIPTION
## 概要

Taskfile.yml の publish タスクをリファクタリングしました。バージョン取得のシェルコマンド展開をインライン記述から Task の vars セクションへ移動することで、可読性と保守性を向上させます。

## 変更内容

- `publish` タスクの `vars` セクションに `VERSION` 変数を定義
- バージョン取得: `sh: node -p "require('./package.json').version"`
- echo コマンドから `{{.VERSION}}` で参照（シェル展開から Task テンプレート変数への変更）

## テスト手順

以下のコマンドで変更が正常に動作することを確認：

```bash
task publish
```

publish タスク実行時に正しくバージョンが表示されることを確認してください。

## 影響範囲

- `Taskfile.yml` のみ
- npm publish の動作に影響なし

## チェックリスト

- [x] Taskfile.yml の構文が正しいことを確認
- [x] 変更が publish タスクの動作を変えないことを確認