### PR TITLE
📝 READMEのリンクテキストを docs から showcase に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 lol, friendly, cute React iconset
 
-[docs](https://lolicon.ichi0g0y.io)
+[showcase](https://lolicon.ichi0g0y.io)
 
 ## Install
 


### PR DESCRIPTION
## Summary

- README.md のリンクテキストを `docs` から `showcase` に修正
- #7 で docs → showcase へリネーム済みだが、README のリンクテキストが古いままだったのを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)